### PR TITLE
Update UI to modern Apple design style

### DIFF
--- a/src/components/desktop/Dock.tsx
+++ b/src/components/desktop/Dock.tsx
@@ -15,7 +15,7 @@ interface DockProps {
 export default function Dock({ items, onItemClick, openWindows = [], minimizedWindows = [], onRestoreWindow }: DockProps) {
   return (
     <div className="fixed bottom-4 left-1/2 -translate-x-1/2 z-40">
-      <div className="flex items-center gap-2 px-4 py-4 bg-white/80 backdrop-blur-sm rounded border">
+      <div className="flex items-center gap-3 px-4 py-3 bg-gray-200/80 backdrop-blur-4xl rounded-2xl">
         {items.map((item, index) => (
           <div key={item.id} className="flex items-center gap-2">
             <DockItem
@@ -26,7 +26,7 @@ export default function Dock({ items, onItemClick, openWindows = [], minimizedWi
             />
             {/* Dividers between groups */}
             {(index === 2 || index === 4) && index < items.length - 1 && (
-              <div className="w-px h-8 bg-gray-400/30" />
+              <div className="w-px h-12 bg-gray-300/60" />
             )}
           </div>
         ))}
@@ -34,7 +34,7 @@ export default function Dock({ items, onItemClick, openWindows = [], minimizedWi
         {/* Minimized Windows */}
         {minimizedWindows.length > 0 && (
           <>
-            <div className="w-px h-8 bg-gray-400/30 mx-1" />
+            <div className="w-px h-12 bg-gray-300/60 mx-1" />
             {minimizedWindows.map((windowId) => {
               const windowConfig = windowId === "terminal"
                 ? { title: "Terminal" }
@@ -47,20 +47,20 @@ export default function Dock({ items, onItemClick, openWindows = [], minimizedWi
                   className="relative group"
                 >
                   {/* Tooltip */}
-                  <div className="absolute -top-14 left-1/2 -translate-x-1/2 opacity-0 group-hover:opacity-100 transition-opacity pointer-events-none">
-                    <div className="relative bg-white border px-3 py-1.5 rounded-lg">
-                      <span className="text-sm text-black whitespace-nowrap">{windowConfig?.title || windowId}</span>
-                      <div className="absolute -bottom-1.5 left-1/2 -translate-x-1/2 w-3 h-3 bg-white border-b border-r rotate-45" />
+                  <div className="absolute -top-12 left-1/2 -translate-x-1/2 opacity-0 group-hover:opacity-100 transition-opacity pointer-events-none">
+                    <div className="relative bg-white/95 backdrop-blur-sm px-4 py-1.5 rounded-full shadow-lg">
+                      <span className="text-sm text-gray-800 whitespace-nowrap font-medium">{windowConfig?.title || windowId}</span>
+                      <div className="absolute -bottom-1.5 left-1/2 -translate-x-1/2 w-3 h-3 bg-white/95 rotate-45" />
                     </div>
                   </div>
                   {/* Minimized window preview using SVG */}
-                  <div className="w-14 h-14 rounded border bg-white flex items-center justify-center hover:scale-110 transition-transform">
+                  <div className="w-14 h-14 rounded-2xl bg-white shadow-md flex items-center justify-center hover:scale-105 transition-transform">
                     <Image
                       src={isDark ? "/mini-window-dark.svg" : "/mini-window-light.svg"}
                       alt={windowConfig?.title || windowId}
-                      width={36}
-                      height={36}
-                      className="w-9 h-9"
+                      width={40}
+                      height={40}
+                      className="w-10 h-10"
                     />
                   </div>
                 </button>

--- a/src/components/desktop/DockItem.tsx
+++ b/src/components/desktop/DockItem.tsx
@@ -32,26 +32,26 @@ export default function DockItem({ icon, label, isOpen, onClick }: DockItemProps
     >
       {/* Tooltip */}
       {label && (
-        <div className="absolute -top-17 left-1/2 -translate-x-1/2 opacity-0 group-hover:opacity-100 transition-opacity pointer-events-none">
-          <div className="relative bg-white border px-3 py-1.5 rounded-lg">
-            <span className="text-sm text-black whitespace-nowrap">{label}</span>
+        <div className="absolute -top-12 left-1/2 -translate-x-1/2 opacity-0 group-hover:opacity-100 transition-opacity pointer-events-none">
+          <div className="relative bg-white/95 backdrop-blur-sm px-4 py-1.5 rounded-full shadow-lg">
+            <span className="text-md text-gray-800 whitespace-nowrap font-regular">{label}</span>
             {/* Triangle pointer */}
-            <div className="absolute -bottom-1.5 left-1/2 -translate-x-1/2 w-3 h-3 bg-white border-b border-r rotate-45" />
+            <div className="absolute -bottom-1.5 left-1/2 -translate-x-1/2 w-3 h-3 bg-white/95 rotate-45" />
           </div>
         </div>
       )}
 
-      <div className="w-14 h-14 rounded border bg-white flex items-center justify-center hover:scale-110 transition-transform">
+      <div className="w-14 h-14 rounded-xl bg-white shadow-md flex items-center justify-center hover:scale-105 transition-transform">
         {imageSrc ? (
           <Image
             src={imageSrc}
             alt={label || icon}
-            width={36}
-            height={36}
-            className="w-9 h-9 object-contain"
+            width={40}
+            height={40}
+            className="w-10 h-10 object-contain"
           />
         ) : (
-          <div className="w-full h-full bg-gray-100 flex items-center justify-center rounded">
+          <div className="w-full h-full bg-white flex items-center justify-center rounded-2xl">
             <span className="text-gray-500 text-xs">{icon}</span>
           </div>
         )}

--- a/src/components/desktop/InfoWidget.tsx
+++ b/src/components/desktop/InfoWidget.tsx
@@ -43,7 +43,7 @@ export default function InfoWidget({ className }: InfoWidgetProps) {
   return (
     <div className={className || "fixed top-12 right-4 z-0"}>
       <div
-        className="rounded border p-5 min-w-[180px] lg:min-w-[200px] bg-cover bg-center"
+        className="rounded-4xl p-5 min-w-[180px] lg:min-w-[200px] bg-cover bg-center shadow-lg"
         style={{ backgroundImage: `url('${bgImage}')` }}
       >
         <div className="flex items-center gap-2 mb-1">

--- a/src/components/desktop/Terminal.tsx
+++ b/src/components/desktop/Terminal.tsx
@@ -133,7 +133,7 @@ export default function Terminal({ isOpen, zIndex, onClose, onFocus, onMinimize 
 
   return (
     <div
-      className={`absolute bg-[#1e1e1e] shadow-2xl overflow-hidden rounded border flex flex-col ${
+      className={`absolute bg-[#1e1e1e]/95 backdrop-blur-xl shadow-2xl overflow-hidden rounded-4xl flex flex-col ${
         isDragging ? "cursor-grabbing" : ""
       } ${isResizing ? "select-none" : ""} ${isMinimizing ? "pointer-events-none" : ""}`}
       style={{

--- a/src/components/desktop/Window.tsx
+++ b/src/components/desktop/Window.tsx
@@ -168,7 +168,7 @@ export default function Window({
   return (
     <div
       ref={windowRef}
-      className={`absolute bg-white shadow-2xl overflow-hidden border rounded flex flex-col ${
+      className={`absolute bg-white/90 backdrop-blur-xl shadow-2xl overflow-hidden rounded-4xl flex flex-col ${
         isDragging ? "cursor-grabbing" : ""
       } ${isResizing ? "select-none" : ""} ${
         isMinimizing ? "pointer-events-none" : "animate-window-open"


### PR DESCRIPTION
- Remove borders, use shadows and backdrop blur instead
- Add rounded corners (rounded-xl, rounded-2xl) to windows and dock
- Update dock with white icon cards and macOS-style tooltips
- Apply glassmorphism effects to windows and terminal